### PR TITLE
add getErrorCode to public API

### DIFF
--- a/src/EmailValidator/EmailValidator.php
+++ b/src/EmailValidator/EmailValidator.php
@@ -93,6 +93,18 @@ class EmailValidator
     }
 
     /**
+     * Returns the error code constant value for invalid email addresses.
+     *
+     * For use by integrating systems to create their own error messages.
+     *
+     * @return int
+     */
+    public function getErrorCode(): int
+    {
+        return $this->reason;
+    }
+
+    /**
      * Returns an error message for invalid email addresses
      *
      * @return string


### PR DESCRIPTION
Please add a public API method to return the raw error code?

### Why?

I have created a Drupal module to utilise this library for more advanced email validation than is available from Drupal core: https://www.drupal.org/project/advanced_email_validation

Drupal modules should support translation, and as such need to create their own error message strings, even if they're exactly the same as the incoming string - which requires reading the incoming message.

Error codes are far less subject to change than error messages. If this library can surface the error codes via the public API, we can expect more stable behaviour from the module.