### PR TITLE
Allow wildcard matching for banned domains

### DIFF
--- a/src/EmailValidator/Validator/BannedListValidator.php
+++ b/src/EmailValidator/Validator/BannedListValidator.php
@@ -10,11 +10,14 @@ class BannedListValidator extends AValidator
 {
     public function validate(EmailAddress $email): bool
     {
-        $valid = true;
         if ($this->policy->checkBannedListedEmail()) {
             $domain = $email->getDomain();
-            $valid = !in_array($domain, $this->policy->getBannedList(), true);
+            foreach ($this->policy->getBannedList() as $bannedDomain) {
+                if (fnmatch($bannedDomain, $domain)) {
+                    return false;
+                }
+            }
         }
-        return $valid;
+        return true;
     }
 }

--- a/tests/EmailValidator/Validator/BannedListValidatorTest.php
+++ b/tests/EmailValidator/Validator/BannedListValidatorTest.php
@@ -11,7 +11,8 @@ class BannedListValidatorTest extends TestCase
     public function dataProvider(): array
     {
         $bannedList = [
-            'example.com'
+            'example.com',
+            '*.example.com',
         ];
 
         return [
@@ -19,6 +20,7 @@ class BannedListValidatorTest extends TestCase
             [$bannedList, 'user@gmail.com'  , true, true],
             [$bannedList, 'user@example.com', false, true],
             [$bannedList, 'user@gmail.com'  , false, true],
+            [$bannedList, 'user@test.example.com', true, false],
         ];
     }
 


### PR DESCRIPTION
We've received a [feature request](https://www.drupal.org/project/advanced_email_validation/issues/3313720) from a user of the Drupal module which makes this library available. Copying the OP here for ease:

**Problem/Motivation**
We are getting spam registrations on our site from multiple different (real mx) domains that have the same second level domain name, but have different (and seemingly randomly-generated) subdomains.

**Proposed resolution**
It would be useful to allow for a wildcard to be used in the banned domain name so that all subdomains of a particular second level domain could be banned. Therefore, instead of the following list that needs to be expanded every time a new subdomain is created/used:

a.emaildomain.com
b.emaildomain.com
c.emaildomain.com

You could instead just enter:

*.emaildomain.com

---------------------

This PR suggests the use of fnmatch to achieve the requested feature.

I wasn't able to run the tests because they're built for PHP 7 but I have altered them in a way that I hope will demonstrate the feature.