### PR TITLE
Removing michenriksen source for disposable emails as it no longer exists.

### DIFF
--- a/src/EmailValidator/Validator/DisposableEmailValidator.php
+++ b/src/EmailValidator/Validator/DisposableEmailValidator.php
@@ -17,10 +17,6 @@ class DisposableEmailValidator extends AProviderValidator
             'url' => 'https://raw.githubusercontent.com/martenson/disposable-email-domains/master/disposable_email_blocklist.conf'
         ],
         [
-            'format' => 'txt',
-            'url' => 'https://gist.githubusercontent.com/michenriksen/8710649/raw/e09ee253960ec1ff0add4f92b62616ebbe24ab87/disposable-email-provider-domains'
-        ],
-        [
             'format' => 'json',
             'url' => 'https://raw.githubusercontent.com/ivolo/disposable-email-domains/master/wildcard.json'
         ],


### PR DESCRIPTION
The email-validator was reporting errors in PHP because of a dependency on a gist that no longer exists. This removes that gist.

https://gist.githubusercontent.com/michenriksen no longer has a repository containing disposable email addresses. The code uses three sources and combines them. So it is safe to remove this one source (which was throwing a 404).